### PR TITLE
don't import catcher in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,11 +3,9 @@
 from distutils.core import setup
 from setuptools import find_packages
 
-import catcher
-
 setup(
     name='python-catcher',
-    version=catcher.__version__,
+    version='0.1.4',
     install_requires=[
         'requests', 'Mako',
     ],


### PR DESCRIPTION
This is preventing `python-catcher` (and any other lib that depends on it, e.g., `ajenti`) from being installed.

Repro:

``` bash
> virtualenv env
> source env/bin/activate
> pip install python-catcher
```

Once this (or some alternative change goes in), **the PyPI package should be updated ASAP**, since this is preventing people from installing dependents of `python-catcher` (e.g., `pip install ajenti` from a fresh python env).
